### PR TITLE
Add capabilities to detect and control AWS Devices 

### DIFF
--- a/src/blueair-api.ts
+++ b/src/blueair-api.ts
@@ -733,6 +733,8 @@ export class BlueAirApi {
         return false;
       }
 
+      this.log.info('Set %s to %s', service, actionValue);
+
       this.log.debug('Response Headers: ', util.inspect(responseHeaders, { colors: true, sorted: true }));
       this.log.debug('Response Body: ', util.inspect(responseBody, { colors: true, sorted: true }));
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -208,13 +208,13 @@ export class BlueAirHomebridgePlatform implements DynamicPlatformPlugin {
           continue;
         }
 
-        const deviceInfo = this.blueair.getAwsDeviceInfo(device.name, device.uuid);
+        const deviceInfo = await this.blueair.getAwsDeviceInfo(device.name, device.uuid);
         //this.log.info('Device Info:', deviceInfo);
 
         this.log.info('Adding new accessory:', device.name);
 
         // create a new accessory
-        const accessory = new this.api.platformAccessory(device.name, uuid);
+        const accessory = new this.api.platformAccessory(deviceInfo[0].configuration.di.name, uuid);
 
         accessory.context.deviceApiName = device.name;
         accessory.context.uuid = device.uuid;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -6,6 +6,7 @@ import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { BlueAirPlatformAccessory } from './platformAccessory';
 import { BlueAirClassicAccessory } from './platformAccessory_Classic';
 import { BlueAirAwareAccessory } from './platformAccessory_Aware';
+import { BlueAirDustProtectAccessory } from './platformAccessory_DustProtect';
 
 /**
  * HomebridgePlatform
@@ -91,8 +92,9 @@ export class BlueAirHomebridgePlatform implements DynamicPlatformPlugin {
 
     // retrieve AWS devices - not yet functional
     if(this.config.enableAWS) {
-      await this.blueair.loginAWS();
-      await this.blueair.getDevicesAWS();
+      await this.blueair.awsLogin();
+      await this.blueair.getAwsDevices();
+      await this.discoverAwsDevices();
     }
 
     // loop over the discovered devices and register each one if it has not already been registered
@@ -150,6 +152,84 @@ export class BlueAirHomebridgePlatform implements DynamicPlatformPlugin {
       // it is possible to remove platform accessories at any time using `api.unregisterPlatformAccessories`, eg.:
       // this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
     // end for
+    }
+
+  }
+
+  async discoverAwsDevices() {
+
+    // login to BlueAir
+    const login_flag: boolean = await this.blueair.awsLogin();
+    if(!login_flag){
+      this.log.error('Failed to login to AWS. Check password and restart Homebridge to try again.');
+      return false;
+    }
+
+    // retrieve devices
+    const devices_flag = await this.blueair.getAwsDevices();
+    if(!devices_flag){
+      this.log.error('Failed to get list of AWS devices. Check BlueAir App.');
+      return false;
+    }
+
+    // loop over the discovered devices and register each one if it has not already been registered
+    for (const device of this.blueair.awsDevices) {
+      // generate a unique id for the accessory this should be generated from
+      // something globally unique, but constant, for example, the device serial
+      // number or MAC address
+      const uuid = this.api.hap.uuid.generate(device.uuid);
+
+      // see if an accessory with the same uuid has already been registered and restored from
+      // the cached devices we stored in the `configureAccessory` method above
+      const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
+
+      if (existingAccessory) {
+        // the accessory already exists
+
+        // Exclude or include certain openers based on configuration parameters.
+        if(!this.optionEnabled(device)) {
+          this.log.info('Removing accessory:', device.uuid);
+          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
+          continue;
+        }
+
+        this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
+
+        this.api.updatePlatformAccessories([existingAccessory]);
+
+        await this.findAwsModelAndInitialize(device, existingAccessory);
+
+      } else {
+        // the accessory does not yet exist, so we need to create it
+
+        // Exclude or include certain openers based on configuration parameters.
+        if(!this.optionEnabled(device)) {
+          this.log.info('Skipping accessory:', device.uuid);
+          continue;
+        }
+
+        const deviceInfo = this.blueair.getAwsDeviceInfo(device.name, device.uuid);
+        //this.log.info('Device Info:', deviceInfo);
+
+        this.log.info('Adding new accessory:', device.name);
+
+        // create a new accessory
+        const accessory = new this.api.platformAccessory(device.name, uuid);
+
+        accessory.context.deviceApiName = device.name;
+        accessory.context.uuid = device.uuid;
+        accessory.context.mac = device.mac;
+        // accessory.context.userid = device.userid;
+
+        await this.findAwsModelAndInitialize(device, accessory);
+
+        // link the accessory to your platform
+        this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+      }
+
+      // it is possible to remove platform accessories at any time using `api.unregisterPlatformAccessories`, eg.:
+      // this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+      // end for
     }
 
   }
@@ -249,5 +329,21 @@ export class BlueAirHomebridgePlatform implements DynamicPlatformPlugin {
         this.log.error('%s: device type not recognized, contact developer via GitHub.', device.name);
     }
 
+  }
+
+  private async findAwsModelAndInitialize(device, accessory){
+      // retreive model info
+      const info = await this.blueair.getAwsDeviceInfo(device.name, device.uuid);
+      this.log.info('Device Info from findAwsModelAndInitialize: ', info);
+      //this.log.info('%s of type "%s" initialized.', device.configuration.di.name, info.compatibility);
+
+      switch (info[0].configuration.di.hw) {
+        case 'b4basic_s_1.1': // B4 = DustProtect
+          this.log.info('Creating new object: BlueAirDustProtectAccessory');
+          new BlueAirDustProtectAccessory(this, accessory);
+          break;
+        default:
+          this.log.error('%s: device type not recognized, contact developer via GitHub.', device.name);
+      }
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -331,6 +331,7 @@ export class BlueAirHomebridgePlatform implements DynamicPlatformPlugin {
 
   }
 
+  // AWS Accessory currently handles DustMagnet and Health Protect
   private async findAwsModelAndInitialize(device, accessory){
       // retreive model info
       const info = await this.blueair.getAwsDeviceInfo(device.name, device.uuid);
@@ -338,7 +339,8 @@ export class BlueAirHomebridgePlatform implements DynamicPlatformPlugin {
       //this.log.info('%s of type "%s" initialized.', device.configuration.di.name, info.compatibility);
 
       switch (info[0].configuration.di.hw) {
-        case 'b4basic_s_1.1': // B4 = DustProtect
+        case 'b4basic_s_1.1': // B4 = DustMagnet
+        case 'high_1.5': // G4 = Health Protect
           this.log.info('Creating new object: BlueAirDustProtectAccessory');
           new BlueAirDustProtectAccessory(this, accessory);
           break;

--- a/src/platformAccessory_DustProtect.ts
+++ b/src/platformAccessory_DustProtect.ts
@@ -345,11 +345,11 @@ export class BlueAirDustProtectAccessory {
 
       // Used 2.5 levels from https://blissair.com/what-is-pm-2-5.htm
       const levels = [
-        [99999, 201, this.platform.Characteristic.AirQuality.POOR],
-        [200, 151, this.platform.Characteristic.AirQuality.INFERIOR],
-        [150, 101, this.platform.Characteristic.AirQuality.FAIR],
-        [100, 51, this.platform.Characteristic.AirQuality.GOOD],
-        [50, 0, this.platform.Characteristic.AirQuality.EXCELLENT],
+        [99999, 201, 5], // 5 = this.platform.Characteristic.AirQuality.POOR
+        [200, 151, 4], // 4 = this.platform.Characteristic.AirQuality.INFERIOR
+        [150, 101, 3], //  3 = this.platform.Characteristic.AirQuality.FAIR
+        [100, 51, 2], // 2 = this.platform.Characteristic.AirQuality.GOOD
+        [50, 0, 1], // 1 = this.platform.Characteristic.AirQuality.EXCELLENT
       ];
 
       const ppm = this.accessory.context.sensorData.pm2_5;
@@ -397,8 +397,13 @@ export class BlueAirDustProtectAccessory {
   }
 
   async updateLED() {
-    // get LED state & brigtness
+    // Check to see if the air purifier is Off (Standby = True); If so, set LED to Off
+    if(this.accessory.context.attributes.standby) {
+        this.Lightbulb.updateCharacteristic(this.platform.Characteristic.On, 0);
+        return true;
+    }
 
+    // get LED state & brigtness
     if(this.accessory.context.attributes.brightness !== undefined) {
       if(this.accessory.context.attributes.brightness > 0) {
         this.Lightbulb.updateCharacteristic(this.platform.Characteristic.On, 1);  
@@ -411,8 +416,13 @@ export class BlueAirDustProtectAccessory {
   }
 
   async updateNightMode() {
-    // get NightMode Status
+    // Check to see if the air purifier is Off (Standby = True); If so, set LED to Off
+    if(this.accessory.context.attributes.standby) {
+      this.NightMode.updateCharacteristic(this.platform.Characteristic.On, 0);
+      return true;
+    }
 
+    // get NightMode Status
     if(this.accessory.context.attributes.nightmode !== undefined) {
       if(this.accessory.context.attributes.nightmode) {
         this.NightMode.updateCharacteristic(this.platform.Characteristic.On, 1);

--- a/src/platformAccessory_DustProtect.ts
+++ b/src/platformAccessory_DustProtect.ts
@@ -436,11 +436,9 @@ export class BlueAirDustProtectAccessory {
 
   async handleAirPurifierActiveSet(state) {
     // Set AirPurifier state
-
     if (state === 1) {
       // Set fan to auto when turned on
       await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'standby', 'vb', false);
-
     } else if (state === 0) {
       // Set fan speed to 0 when turned off
       await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'standby', 'vb', true);
@@ -496,6 +494,11 @@ export class BlueAirDustProtectAccessory {
     if(state === false){ // Night Mode Off
       await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'nightmode', 'vb', false);
     } else if (state === true){ // Night Mode On
+      // If Air Purifier is turned off, first turn it on
+      if(this.accessory.context.attributes.standby) {
+        // Set fan to auto when turned on
+        await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'standby', 'vb', false);
+      }
       await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'nightmode', 'vb', true);
     }
   }

--- a/src/platformAccessory_DustProtect.ts
+++ b/src/platformAccessory_DustProtect.ts
@@ -1,0 +1,446 @@
+import { Service, PlatformAccessory } from 'homebridge';
+
+import fakegato from 'fakegato-history';
+
+import { BlueAirHomebridgePlatform } from './platform';
+
+import { BLUEAIR_DEVICE_WAIT } from './settings';
+
+export class BlueAirDustProtectAccessory {
+  // setup device services
+  private AirPurifier: Service;
+  private AirQualitySensor: Service;
+  private FilterMaintenance: Service;
+  private Lightbulb: Service;
+
+  // store last query to BlueAir API
+  private lastquery;
+
+  // setup fake-gato history service for Eve support
+  private historyService: fakegato.FakeGatoHistoryService;
+
+  constructor(
+    private readonly platform: BlueAirHomebridgePlatform,
+    private readonly accessory: PlatformAccessory,
+  ) {
+
+    // set model name, firware, etc.
+    this.setAccessoryInformation();
+
+    this.platform.log.info('Accessor object', this.accessory);
+
+    // initiate services
+    this.AirPurifier = this.accessory.getService(this.platform.Service.AirPurifier) || 
+      this.accessory.addService(this.platform.Service.AirPurifier);
+    this.AirQualitySensor = this.accessory.getService(this.platform.Service.AirQualitySensor) ||
+      this.accessory.addService(this.platform.Service.AirQualitySensor);
+    this.FilterMaintenance = this.accessory.getService(this.platform.Service.FilterMaintenance) ||
+      this.accessory.addService(this.platform.Service.FilterMaintenance);
+    this.Lightbulb = this.accessory.getService(this.platform.Service.Lightbulb) || 
+      this.accessory.addService(this.platform.Service.Lightbulb);
+    
+    // create handlers for characteristics
+    this.AirPurifier.getCharacteristic(this.platform.Characteristic.Active)
+      .onGet(this.handleAirPurifierActiveGet.bind(this))
+      .onSet(this.handleAirPurifierActiveSet.bind(this));
+
+    this.AirPurifier.getCharacteristic(this.platform.Characteristic.CurrentAirPurifierState)
+      .onGet(this.handleCurrentAirPurifierStateGet.bind(this));
+
+    this.AirPurifier.getCharacteristic(this.platform.Characteristic.TargetAirPurifierState)
+      .onGet(this.handleTargetAirPurifierGet.bind(this))
+      .onSet(this.handleTargetAirPurifierSet.bind(this));
+
+    this.AirPurifier.getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+      .onGet(this.handleLockPhysicalControlsGet.bind(this))
+      .onSet(this.handleLockPhysicalControlsSet.bind(this));
+
+    this.AirPurifier.getCharacteristic(this.platform.Characteristic.RotationSpeed)
+      .onGet(this.handleRotationSpeedGet.bind(this))
+      .onSet(this.handleRotationSpeedSet.bind(this));
+
+    this.AirQualitySensor.getCharacteristic(this.platform.Characteristic.PM2_5Density)
+      .onGet(this.handlePM25DensityGet.bind(this));
+
+    this.FilterMaintenance.getCharacteristic(this.platform.Characteristic.FilterChangeIndication)
+      .onGet(this.handleFilterChangeGet.bind(this));
+
+    this.FilterMaintenance.getCharacteristic(this.platform.Characteristic.FilterLifeLevel)
+      .onGet(this.handleFilterLifeLevelGet.bind(this));
+
+    this.Lightbulb.getCharacteristic(this.platform.Characteristic.On)
+      .onGet(this.handleOnGet.bind(this))
+      .onSet(this.handleOnSet.bind(this));
+
+    this.Lightbulb.getCharacteristic(this.platform.Characteristic.Brightness)
+      .onGet(this.handleBrightnessGet.bind(this))
+      .onSet(this.handleBrightnessSet.bind(this));
+
+  }
+
+  async setAccessoryInformation() {
+    // setup information for each accessory
+
+    await this.updateDevice();
+
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'BlueAir')
+      .setCharacteristic(this.platform.Characteristic.Model, 'DustProtect')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.context.configuration.di.ds)
+      .setCharacteristic(this.platform.Characteristic.FirmwareRevision, this.accessory.context.configuration.di.mfv);
+
+  }
+ 
+  async updateDevice() {
+    // update accessory.context with latest values from BlueAir
+
+    if ((Date.now() - BLUEAIR_DEVICE_WAIT) < this.lastquery) {
+      //this.platform.log.debug('Recent update from device already performed.');
+      if(!this.accessory.context.attributes) {
+        this.platform.log.error('%s: accessory context not set', this.accessory.displayName);
+        return false;
+      }
+      //this.platform.log.debug('%s: using old data', this.accessory.displayName);
+      return true; //ok to use current data in context to update Characteristic values
+    }
+    this.lastquery = Date.now(); // update time of last query
+
+    try{
+      this.platform.log.debug('Accessory Info: ', this.accessory);
+      this.platform.log.debug('Accessory Name: ', this.accessory.context.deviceApiName);
+      this.platform.log.debug('Accessory UUID: ', this.accessory.context.uuid);
+      const info = await this.platform.blueair.getAwsDeviceInfo(this.accessory.context.deviceApiName, this.accessory.context.uuid);
+      if(!info){
+        this.platform.log.error('%s: getDeviceInfo failed.', this.accessory.displayName);
+        return false;
+      }
+
+      this.accessory.context.configuration = info[0].configuration;
+      this.accessory.context.sensorData = info[0].sensorData;
+
+      const sensorData = {};
+      for (let i=0; i < info[0].sensordata.length; i++) {
+        this.platform.log.info('Accessory Sensor #', i);
+        this.platform.log.info('Accessory Sensor', info[0].sensordata[i]);
+        if (info[0].sensordata[i].hasOwnProperty('v')) {
+          sensorData[info[0].sensordata[i].n] = info[0].sensordata[i].v;
+        } else if (info[0].states[i].hasOwnProperty('vb')) {
+          sensorData[info[0].sensordata[i].n] = info[0].sensordata[i].vb;
+        }
+      }
+
+      const attributes = {};
+      for (let i=0; i < info[0].states.length; i++) {
+          this.platform.log.info('Accessory State #', i);
+          this.platform.log.info('Accessory State', info[0].states[i]);
+          if (info[0].states[i].hasOwnProperty('v')) {
+              attributes[info[0].states[i].n] = info[0].states[i].v;
+          } else if (info[0].states[i].hasOwnProperty('vb')) {
+              attributes[info[0].states[i].n] = info[0].states[i].vb;
+          }
+      }
+
+      this.accessory.context.sensorData = sensorData;
+      this.accessory.context.attributes = attributes;
+      this.platform.log.debug('Accessory Context', this.accessory.context);
+
+      // Update Device Display Name
+      this.accessory.displayName = this.accessory.context.configuration.di.name;
+    } catch(error) {
+      this.platform.log.error('%s: getDeviceInfo error. %s', this.accessory.displayName, error);
+      return false;
+    }
+
+    //this.accessory.context.info.filterlevel = 100 - 0;
+    //this.platform.log.info('%s: Filter life left %s', this.accessory.displayName, this.accessory.context.info.filterlevel);
+
+    return true;
+  }
+
+  // handlers GET
+
+  async handleAirPurifierActiveGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.AirPurifier.getCharacteristic(this.platform.Characteristic.Active).value;
+  }
+
+  async handleCurrentAirPurifierStateGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.AirPurifier.getCharacteristic(this.platform.Characteristic.CurrentAirPurifierState).value;
+  }
+
+  async handleTargetAirPurifierGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.AirPurifier.getCharacteristic(this.platform.Characteristic.TargetAirPurifierState).value;
+  }
+
+  async handleLockPhysicalControlsGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.AirPurifier.getCharacteristic(this.platform.Characteristic.LockPhysicalControls).value;
+  }
+
+  async handleRotationSpeedGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.AirPurifier.getCharacteristic(this.platform.Characteristic.RotationSpeed).value;
+  }
+
+  async handlePM25DensityGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.AirQualitySensor.getCharacteristic(this.platform.Characteristic.PM2_5Density).value;
+  }
+
+  async handleFilterChangeGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.FilterMaintenance.getCharacteristic(this.platform.Characteristic.FilterChangeIndication).value;
+  }
+
+  async handleFilterLifeLevelGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.FilterMaintenance.getCharacteristic(this.platform.Characteristic.FilterLifeLevel).value;
+  }
+
+  async handleOnGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.Lightbulb.getCharacteristic(this.platform.Characteristic.On).value;
+  }
+
+  async handleBrightnessGet() {
+    await this.updateAccessoryCharacteristics();
+    return this.Lightbulb.getCharacteristic(this.platform.Characteristic.Brightness).value;
+  }
+ 
+  // common function to update all characteristics
+  async updateAccessoryCharacteristics() {
+    // updateAccessoryCharacteristics
+
+    // update context.device information from Kumo or Directly
+    const status: boolean = await this.updateDevice();
+    if(!status) { 
+      this.platform.log.info('updateAccessoryCharacteristic failed (%s)', this.accessory.context.uuid);
+      return false;
+    }
+
+    // update characteristics from this.accessory.context
+    await this.updateAirPurifierActiveState();
+    await this.updateAirPurifierCurrentAirPurifierState();
+    await this.updateAirPurifierTargetAirPurifierState();
+    await this.updateAirPurifierLockPhysicalControl();
+    await this.updateAirPurifierRotationSpeed();
+    await this.updateAirQualitySensor();
+    await this.updateFilterMaintenance();
+    await this.updateLED();
+
+    return true;
+  }
+
+  async updateAirPurifierActiveState() {
+    // AirPurifier Active
+
+    let currentValue: number = <number>this.AirPurifier.getCharacteristic(this.platform.Characteristic.Active).value;
+    
+    if(this.accessory.context.attributes.standby){
+      currentValue = this.platform.Characteristic.Active.INACTIVE;
+    } else if (!this.accessory.context.attributes.standby) {
+      currentValue = this.platform.Characteristic.Active.ACTIVE;
+    } else {
+      this.platform.log.error('%s: failed to determine active state.', this.accessory.displayName);
+      return false;
+    }
+
+    this.platform.log.debug('%s: Active is %s', this.accessory.displayName, currentValue);
+    this.AirPurifier.updateCharacteristic(this.platform.Characteristic.Active, currentValue);
+    return true;
+  }
+
+  async updateAirPurifierCurrentAirPurifierState() {
+    // AirPurifier Current State
+
+    let currentValue: number = <number>this.AirPurifier.getCharacteristic(this.platform.Characteristic.CurrentAirPurifierState).value;
+    
+    if(!this.accessory.context.attributes.standby){
+      currentValue = this.platform.Characteristic.CurrentAirPurifierState.PURIFYING_AIR;
+    } else {
+      currentValue = this.platform.Characteristic.CurrentAirPurifierState.INACTIVE;
+    }
+
+    this.platform.log.debug('%s: CurrentState is %s', this.accessory.displayName, currentValue);
+    this.AirPurifier.updateCharacteristic(this.platform.Characteristic.CurrentAirPurifierState, currentValue);
+    return true;
+  }
+
+  async updateAirPurifierTargetAirPurifierState() {
+    // AirPurifier Target State
+
+    let currentValue: number = <number>this.AirPurifier.getCharacteristic(this.platform.Characteristic.TargetAirPurifierState).value;
+    
+    if(this.accessory.context.attributes.automode){
+      currentValue = this.platform.Characteristic.TargetAirPurifierState.AUTO;
+    } else if (!this.accessory.context.attributes.automode){
+      currentValue = this.platform.Characteristic.TargetAirPurifierState.MANUAL;
+    }
+
+    this.platform.log.debug('%s: TargetState is %s', this.accessory.displayName, currentValue); 
+    this.AirPurifier.updateCharacteristic(this.platform.Characteristic.TargetAirPurifierState, currentValue);
+    return true;
+  }
+
+  async updateAirPurifierLockPhysicalControl() {
+    // AirPurifier Physical Control
+
+    let currentValue: number = <number>this.AirPurifier.getCharacteristic(this.platform.Characteristic.LockPhysicalControls).value;
+    
+    if(this.accessory.context.attributes.childlock){
+      currentValue = this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED;
+    } else {
+      currentValue = this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED;
+    }
+
+    this.platform.log.debug('%s: LockPhysicalControl is %s', this.accessory.displayName, currentValue); 
+    this.AirPurifier.updateCharacteristic(this.platform.Characteristic.LockPhysicalControls, currentValue);
+    return true;
+  }
+
+  async updateAirPurifierRotationSpeed() {
+    // AirPurifier Rotation Speed
+
+    const fan_speed: number = this.accessory.context.attributes.fanspeed;
+    this.platform.log.debug('%s: fan_speed is %s', this.accessory.displayName, fan_speed);
+
+    let currentValue: number = <number>this.AirPurifier.getCharacteristic(this.platform.Characteristic.RotationSpeed).value;
+    if (fan_speed !== undefined) {
+      currentValue = fan_speed;
+    } else {
+      // rotation speed not reported from device
+      return false;
+    }
+
+    this.platform.log.debug('%s: RotationsSpeed is %s', this.accessory.displayName, currentValue); 
+    this.AirPurifier.updateCharacteristic(this.platform.Characteristic.RotationSpeed, currentValue);
+    return true;
+  }
+
+  async updateAirQualitySensor() {
+    // Update AirQuality measurements
+    if(this.accessory.context.sensorData !== undefined) {
+      this.platform.log.debug('Sensor Data: ', this.accessory.context.sensorData);
+      // Characteristic triggers warning if value over 1000
+      if(this.accessory.context.sensorData.pm2_5 !== undefined){
+        this.AirQualitySensor.updateCharacteristic(this.platform.Characteristic.PM2_5Density, this.accessory.context.sensorData.pm2_5);
+        this.AirPurifier.updateCharacteristic(this.platform.Characteristic.PM2_5Density, this.accessory.context.sensorData.pm2_5);
+        this.platform.log.debug('Sensor Data - PM 2.5: ', this.accessory.context.sensorData.pm2_5);
+      }
+
+      const levels = [
+        [99999, 201, this.platform.Characteristic.AirQuality.POOR],
+        [200, 151, this.platform.Characteristic.AirQuality.INFERIOR],
+        [150, 101, this.platform.Characteristic.AirQuality.FAIR],
+        [100, 51, this.platform.Characteristic.AirQuality.GOOD],
+        [50, 0, this.platform.Characteristic.AirQuality.EXCELLENT],
+      ];
+
+      const ppm = this.accessory.context.sensorData.pm2_5;
+
+      let AirQuality;
+      for(const item of levels){
+        if(ppm >= item[1] && ppm <= item[0]){
+          AirQuality = item[2];
+        }
+      }
+      //this.platform.log.debug('%s: AirQuality = %s', this.accessory.displayName, AirQuality);
+
+      this.AirQualitySensor.updateCharacteristic(this.platform.Characteristic.AirQuality, AirQuality);
+      this.AirPurifier.updateCharacteristic(this.platform.Characteristic.AirQuality, AirQuality);
+    }
+  }
+
+  async updateFilterMaintenance() {
+    // Update Filter maintenance
+
+    if(this.accessory.context.attributes.filterusage !== undefined) {
+      if(this.accessory.context.attributes.filterusage > 0) {
+        this.FilterMaintenance.updateCharacteristic(this.platform.Characteristic.FilterLifeLevel, this.accessory.context.attributes.filterusage);
+      } else {
+        this.FilterMaintenance.updateCharacteristic(this.platform.Characteristic.FilterLifeLevel, 0);
+      }
+    } else {
+      this.platform.log.error('%s: no filterlife found.', this.accessory.displayName);
+      return false;
+    }
+
+    return true;
+  }
+
+  async updateLED() {
+    // get LED state & brigtness
+
+    if(this.accessory.context.attributes.brightness !== undefined) {
+      if(this.accessory.context.attributes.brightness > 0) {
+        this.Lightbulb.updateCharacteristic(this.platform.Characteristic.On, 1);  
+      } else {
+        this.Lightbulb.updateCharacteristic(this.platform.Characteristic.On, 0);  
+      }
+
+      this.Lightbulb.updateCharacteristic(this.platform.Characteristic.Brightness, this.accessory.context.attributes.brightness);
+    }
+  }
+
+  // handlers SET
+
+  async handleAirPurifierActiveSet(state) {
+    // Set AirPurifier state
+
+    if (state === 1) {
+      // Set fan to auto when turned on
+      await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'standby', 'vb', false);
+
+    } else if (state === 0) {
+      // Set fan speed to 0 when turned off
+      await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'standby', 'vb', true);
+    }
+  }
+
+  async handleTargetAirPurifierSet(state) {
+    // Set fan to auto turned on without a speed set
+    if(state === 0){ // Manual
+      await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'automode', 'vb', false);
+    } else if (state === 1){ // Auto
+      await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'automode', 'vb', true);
+    }
+  }
+
+  async handleLockPhysicalControlsSet(state) {
+    // Set child lock state
+
+    if(state === 0){ // Child Lock Unlocked
+      await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'childlock', 'vb', false);
+    } else if (state === 1){ // Child Lock Locked
+      await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'childlock', 'vb', true);
+    }
+  }
+
+  async handleRotationSpeedSet(value) {
+    // Set fan rotation speed  
+    await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'fanspeed', 'v', value);
+  }
+
+  async handleOnSet(state) {
+    // Set LightBulb on
+
+    let brightness;
+    if(state === true) {
+      brightness = this.accessory.context.attributes.brightness;
+    } else if (state === false) {
+      brightness = 0;
+    }
+
+    await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'brightness', 'v', brightness);
+  }
+
+  async handleBrightnessSet(value) {
+    // Set LightBulb brightness
+    await this.platform.blueair.setAwsDeviceInfo(this.accessory.context.uuid, 'brightness', 'v', value);
+  }
+
+}
+
+


### PR DESCRIPTION
Related to #1 

Add capabilities to detect and control AWS Devices (specifically DustProtect, although others may be compatible), get status readings from Air quality sensor (PM 2.5) and all other telemetry, register device with Homebridge, and establish all main getters/setters.

TODO:
- Clean up logging
- Review error handling
- Consider refactoring code into new AWS specific files
- Identify other models for switch statement in platform.ts
- Find out if there is a way to add Characteristic for Night Mode
- Research why when turning on and off via Home.app, the status hangs on "Turning On..." or "Turning Off..."
- Perform testing with other models
- Fix display name in Homebridge/Home.app to show display name rather than deviceApiName