### PR TITLE
Temporary Workaround for AWS Timeout

### DIFF
--- a/src/platformAccessory_DustProtect.ts
+++ b/src/platformAccessory_DustProtect.ts
@@ -132,10 +132,20 @@ export class BlueAirDustProtectAccessory {
       this.platform.log.debug('Accessory Info: ', this.accessory);
       this.platform.log.debug('Accessory Name: ', this.accessory.context.deviceApiName);
       this.platform.log.debug('Accessory UUID: ', this.accessory.context.uuid);
-      const info = await this.platform.blueair.getAwsDeviceInfo(this.accessory.context.deviceApiName, this.accessory.context.uuid);
+      let info = await this.platform.blueair.getAwsDeviceInfo(this.accessory.context.deviceApiName, this.accessory.context.uuid);
       if(!info){
         this.platform.log.error('%s: getDeviceInfo failed.', this.accessory.displayName);
-        return false;
+
+        this.platform.log.debug('Attempting to re-login and refresh Access and Refresh tokens for: %s', this.accessory.displayName);
+        const retryLogin = await this.platform.blueair.awsLogin();
+        this.platform.log.debug('retryLogin result: %s', retryLogin);
+
+        info = await this.platform.blueair.getAwsDeviceInfo(this.accessory.context.deviceApiName, this.accessory.context.uuid);
+
+        if(!info) {
+          this.platform.log.error('%s: getDeviceInfo failed.', this.accessory.displayName);
+          return false;
+        }
       }
 
       this.accessory.context.configuration = info[0].configuration;
@@ -275,7 +285,7 @@ export class BlueAirDustProtectAccessory {
     await this.updateFilterMaintenance();
     await this.updateLED();
     await this.updateNightMode();
-    if(this.accessory.context.configuration.di.hw == 'high_1.5') {
+    if(this.accessory.context.configuration.di.hw === 'high_1.5') {
       await this.updateGermShield();
     }
 


### PR DESCRIPTION
- Re-attempt login to refresh JWT, Access, and Refresh tokens if API calls are failing. (temporary workaround until proper protocol for rotating tokens can be identified for #18)

- Fix ES Lint Warning(s)