### PR TITLE
Refactor AWS Token Expiration Checks

### DIFF
--- a/src/platformAccessory_DustProtect.ts
+++ b/src/platformAccessory_DustProtect.ts
@@ -132,20 +132,9 @@ export class BlueAirDustProtectAccessory {
       this.platform.log.debug('Accessory Info: ', this.accessory);
       this.platform.log.debug('Accessory Name: ', this.accessory.context.deviceApiName);
       this.platform.log.debug('Accessory UUID: ', this.accessory.context.uuid);
-      let info = await this.platform.blueair.getAwsDeviceInfo(this.accessory.context.deviceApiName, this.accessory.context.uuid);
+      const info = await this.platform.blueair.getAwsDeviceInfo(this.accessory.context.deviceApiName, this.accessory.context.uuid);
       if(!info){
         this.platform.log.error('%s: getDeviceInfo failed.', this.accessory.displayName);
-
-        this.platform.log.debug('Attempting to re-login and refresh Access and Refresh tokens for: %s', this.accessory.displayName);
-        const retryLogin = await this.platform.blueair.awsLogin();
-        this.platform.log.debug('retryLogin result: %s', retryLogin);
-
-        info = await this.platform.blueair.getAwsDeviceInfo(this.accessory.context.deviceApiName, this.accessory.context.uuid);
-
-        if(!info) {
-          this.platform.log.error('%s: getDeviceInfo failed.', this.accessory.displayName);
-          return false;
-        }
       }
 
       this.accessory.context.configuration = info[0].configuration;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,5 +13,7 @@ export const BLUEAIR_APIKEY = 'eyJhbGciOiJIUzI1NiJ9.eyJncmFudGVlIjoiYmx1ZWFpciIs
 
 export const BLUEAIR_DEVICE_WAIT = 5000;
 
+export const BLUEAIR_LOGIN_WAIT = 82800000; // 23 hours
+
 export const BLUEAIR_AWS_APIKEY = '3_-xUbbrIY8QCbHDWQs1tLXE-CZBQ50SGElcOY5hF1euE11wCoIlNbjMGAFQ6UwhMY';
 


### PR DESCRIPTION
- Rework for #18 to store token expiration date/time (API will expire after 24 hours, but I have used 23 hours in settings proactively)
- Add check to all getters and setters to see if tokens are expired; if so, awsLogin will be re-executed.